### PR TITLE
Enable Dependabot Automerging

### DIFF
--- a/automerge.yml
+++ b/automerge.yml
@@ -1,0 +1,14 @@
+name: CI  
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: patch
+          github-token: ${{ secrets.mytoken }}


### PR DESCRIPTION
We'll need to add a token in the repo secrets to allow this action to run. I don't have access to the repo secrets; I've just checked :P Refer to [this section in the action's docs](https://github.com/marketplace/actions/dependabot-auto-merge#token-scope)

There may be problems with syntax here as well. My brain's really tired right now so I don't want to spend energy figuring that out.